### PR TITLE
Handle rails 4.1 not symbolizing nested hashes

### DIFF
--- a/lib/simple_admin_auth/authenticated.rb
+++ b/lib/simple_admin_auth/authenticated.rb
@@ -16,9 +16,10 @@ module SimpleAdminAuth
     end
 
     def self.is_admin?(session)
+      admin_session = get_session_key(session, :admin_user)
       valid_admin = false
-      if !session[:admin_user].nil? && !session[:admin_user][:email].nil?
-        email = session[:admin_user][:email]
+      if !admin_session.nil? && !get_session_key(admin_session, :email).nil?
+        email = get_session_key(admin_session, :email)
         if !SimpleAdminAuth::Configuration.email_white_list.nil?
           if SimpleAdminAuth::Configuration.email_white_list.include?(email)
             valid_admin = true
@@ -28,6 +29,11 @@ module SimpleAdminAuth
         end
       end
       valid_admin
+    end
+
+    private 
+    def self.get_session_key(hash, symbol)
+      (hash[symbol] || hash[symbol.to_s])
     end
   end
 

--- a/spec/authenticate_spec.rb
+++ b/spec/authenticate_spec.rb
@@ -26,12 +26,25 @@ describe SimpleAdminAuth::Authenticate do
     }
   end
 
+  let(:admin_string_sessions) do 
+    {
+      admin_user:{
+        'email'=> 'admin@example.com',
+        'name'=> 'dummy'
+      } 
+    }
+  end
+
   before do
     SimpleAdminAuth::Configuration.email_white_list = nil
   end
 
   it 'should authenticate if admin email is set ' do 
     auth.is_admin?(admin_session).should eq(true)
+  end
+
+  it 'should authenticate if admin email is set in a string key' do 
+    auth.is_admin?(admin_string_sessions).should eq(true)
   end
 
   it 'should not authenticate with empty session ' do 


### PR DESCRIPTION
So it appears rails 4.1 changed the way their convert the cookies to not try and symbolize nested keys 

http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#cookies-serializer

This simply tries both keys. A nicer way would be use hashwithindifferentaccess but wasn't sure if that was safe to use here? If you would like the gem to depend on ActiveSupport as well I am happy to switch it out.
